### PR TITLE
Fix look-ahead bias

### DIFF
--- a/bitcoin-analysis-and-backtest-with-moving-avarege.ipynb
+++ b/bitcoin-analysis-and-backtest-with-moving-avarege.ipynb
@@ -1732,7 +1732,7 @@
     "df_MA_trade_btc_usd.loc[(df_MA_trade_btc_usd['MA_short'] < df_MA_trade_btc_usd['MA_long']), 'Order'] = -1\n",
     "\n",
     "# Calculate return\n",
-    "df_MA_trade_btc_usd[\"MA_return\"] = df_MA_trade_btc_usd[\"Auto_pct\"] * df_MA_trade_btc_usd[\"Order\"]"
+    "df_MA_trade_btc_usd["MA_return"] = df_MA_trade_btc_usd["Auto_pct"] * df_MA_trade_btc_usd["Order"].shift(1)"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- prevent using same-day prices when computing `MA_return`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6870587aabbc83329a0361495dc4d87e